### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     # Only update Wormhole dependencies
     allow:
-      - dependency-name: "@wormhole-foundation/*" 
+      - dependency-name: "@wormhole-foundation/*"


### PR DESCRIPTION
## Summary

The following zizmor findings were fixed:

- **dependabot-cooldown** (`.github/dependabot.yml`): Added `cooldown.default-days: 7` to the npm package ecosystem block to satisfy the minimum cooldown requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)